### PR TITLE
Fix(form): Correct lead submission and email personalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,60 @@
+# ️ Bug Fixes Documentation – Lead Capture (v1.0.1)
+
+## Overview
+This document outlines the major bugs that were discovered and resolved in the Lead Capture Application.
+---
+## Critical Fixes Implemented
+### 1. Duplicate Confirmation Emails and No Database persistence
+**File**: `src/components/LeadCaptureForm.tsx`
+**Severity**: Critical
+**Status**: Fixed
+#### Problem
+The lead capture form was sending two confirmation emails for every submission and was not saving the lead's data to the database. This resulted in:
+- Annoying users with duplicate emails.
+- Loss of valuable lead data.
+- Inability to follow up with potential customers.
+#### Root Cause
+A copy-paste error in the form submission handler caused the `send-confirmation` function to be called twice. The code block that was intended to save the data to the database was instead calling the email function.
+#### Fix
+The duplicate function call was removed and replaced with the correct Supabase query to insert the lead into the `leads` table.
+```typescript
+// Before
+try {
+  const { error: emailError } = await supabase.functions.invoke('send-confirmation', { ... });
+} ...
+
+// After
+try {
+  const { error: dbError } = await supabase.from('leads').insert([ ... ]);
+} ...
+```
+#### Impact
+- ✅ Lead data is now correctly saved to the database.
+- ✅ Users receive only one confirmation email.
+- ✅ Improved data integrity and user experience.
+---
+### 2. AI-Powered Email Personalization Failed
+**File**: `supabase/functions/send-confirmation/index.ts`
+**Severity**: High
+**Status**: ✅ Fixed
+
+#### Problem
+The confirmation emails were not being personalized using the OpenAI API as intended. Instead, a generic fallback message was being sent to all users.
+#### Root Cause
+The code was attempting to access the AI-generated content from the wrong index in the OpenAI API response array. It was using `choices[1]` instead of `choices[0]`.
+#### Fix
+The code was updated to access the correct index (`[0]`) in the `choices` array of the OpenAI API response.
+```typescript
+// Before
+return data?.choices[1]?.message?.content;
+
+// After
+return data?.choices[0]?.message?.content;
+```
+#### Impact
+- ✅ Confirmation emails are now personalized for each user based on their industry.
+- ✅ Increased user engagement and a more welcoming experience.
+
 # Welcome to your Lovable project
 
 ## Project info

--- a/src/components/LeadCaptureForm.tsx
+++ b/src/components/LeadCaptureForm.tsx
@@ -27,23 +27,19 @@ export const LeadCaptureForm = () => {
 
     if (errors.length === 0) {
       // Save to database
-try {
-  const { error: emailError } = await supabase.functions.invoke('send-confirmation', {
-    body: {
-      name: formData.name,
-      email: formData.email,
-      industry: formData.industry,
-    },
-  });
+      try {
+        const { error: dbError } = await supabase.from('leads').insert([
+          { name: formData.name, email: formData.email, industry: formData.industry },
+        ]);
 
-  if (emailError) {
-    console.error('Error sending confirmation email:', emailError);
-  } else {
-    console.log('Confirmation email sent successfully');
-  }
-} catch (emailError) {
-  console.error('Error calling email function:', emailError);
-}
+        if (dbError) {
+          console.error('Error saving lead to database:', dbError);
+        } else {
+          console.log('Lead saved to database successfully');
+        }
+      } catch (dbError) {
+        console.error('Error inserting lead:', dbError);
+      }
 
       // Send confirmation email
       try {
@@ -68,7 +64,7 @@ try {
         name: formData.name,
         email: formData.email,
         industry: formData.industry,
-        submitted_at: new Date().toISOString(), 
+        submitted_at: new Date().toISOString(),
       };
       setLeads([...leads, lead]);
       setSubmitted(true);

--- a/supabase/functions/send-confirmation/index.ts
+++ b/supabase/functions/send-confirmation/index.ts
@@ -42,7 +42,7 @@ const generatePersonalizedContent = async (name: string, industry: string) => {
     });
 
     const data = await response.json();
-    return data?.choices[1]?.message?.content;
+    return data?.choices[0]?.message?.content;
   } catch (error) {
     console.error('Error generating personalized content:', error);
     // Fallback content


### PR DESCRIPTION
This commit addresses two critical bugs in the lead capture process:

1.  **Duplicate Emails and No DB Persistence:** The lead capture form was sending two confirmation emails and not saving lead data to the database due to a duplicated function call. This has been corrected by replacing the erroneous call with a proper Supabase insert operation.

2.  **AI Personalization Failure:** The email personalization was failing because it was accessing an incorrect index in the OpenAI API response. The Supabase function has been updated to use the correct index, ensuring that personalized emails are sent.

Additionally, a detailed bug fix report has been added to the README.md to document these changes.